### PR TITLE
no need to override the UIWindow methods if you're in release mode

### DIFF
--- a/NetworkEye/NetworkEye/UIWindow+NEExtension.m
+++ b/NetworkEye/NetworkEye/UIWindow+NEExtension.m
@@ -11,18 +11,16 @@
 
 @implementation UIWindow (NEExtension)
 
-- (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event {
 #if defined(DEBUG)||defined(_DEBUG)
- 
+- (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event {
+
     if (event.type == UIEventTypeMotion && event.subtype == UIEventSubtypeMotionShake) {
         [[NEShakeGestureManager defaultManager] showAlertView];
     }
-#endif
   
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-#if defined(DEBUG)||defined(_DEBUG)
  
     int twoFingerTag=NO;
     if ([event allTouches].count==2) {
@@ -37,8 +35,8 @@
     if (twoFingerTag) {
         [[NEShakeGestureManager defaultManager] showAlertView];
     }
-#endif
   
 }
+#endif
 
 @end


### PR DESCRIPTION
very minor change. 
moving the prerocessor macro to encapsulate the method overrides.
it might prevent a collision with other shake gesture recognizer in release mode.
