### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Note：Use Network Eye in DEBUG mode
 
 add the code in AppDelegate.m   
 <pre>
-#import "NEHTTPEye.h"
-#if defined(DEBUG)||defined(_DEBUG)
+# import "NEHTTPEye.h"
+# if defined(DEBUG)||defined(_DEBUG)
     [NEHTTPEye setEnabled:YES];
-#endif
+# endif
 </pre>
 
 you can use use the shortcut (⌘ Command + n) , a double tap or shake device to call out the monitoring data interface
@@ -61,10 +61,10 @@ NEHTTPEyeViewController
 
 You can also use the following code present out directly
 <pre>
-#if defined(DEBUG)||defined(_DEBUG)
+# if defined(DEBUG)||defined(_DEBUG)
     NEHTTPEyeViewController *vc=[[NEHTTPEyeViewController alloc] init];
     [self presentViewController:vc animated:YES completion:nil];
-#endif
+# endif
 </pre>
 In NEHTTPEye.h there are two parameters you can configure that is the default password of database is "networkeye" ,and by default set,you can save 300 requests.
 
@@ -72,9 +72,9 @@ In NEHTTPEye.h there are two parameters you can configure that is the default pa
 the database name is networkeye.sqlite,and stored in the cache directory.
 
 <pre>
-#define kSQLitePassword @"networkeye"
+# define kSQLitePassword @"networkeye"
 
-#define kSaveRequestMaxCount 300
+# define kSaveRequestMaxCount 300
 </pre>
 
 you can change it use NEHTTPModelManager

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -18,30 +18,30 @@ pod 'NetworkEye', '~> 1.0.1'
 ```
 
 
-######使用:
+###### 使用:
 注意请在DEBUG模式下使用NetworkEye
 在AppDelegate.m里面加入下面代码就可以了
 <pre>
-#import "NEHTTPEye.h"
-#if defined(DEBUG)||defined(_DEBUG)
+# import "NEHTTPEye.h"
+# if defined(DEBUG)||defined(_DEBUG)
     [NEHTTPEye setEnabled:NO];
-#endif
+# endif
 </pre>
 
 使用的时候可以通过双指轻拍或者摇一摇（Shake Gesture）手势调出监控数据界面NEHTTPEyeViewController
 也可以用如下代码直接present出来。
 <pre>
-#if defined(DEBUG)||defined(_DEBUG)
+# if defined(DEBUG)||defined(_DEBUG)
     NEHTTPEyeViewController *vc=[[NEHTTPEyeViewController alloc] init];
     [self presentViewController:vc animated:YES completion:nil];
-#endif
+# endif
 </pre>
 
 在NEHTTPEye.h里面有两个可以配置的参数即默认数据库密码是networkeye和默认监控最多300条请求，请求的保存位置在缓存目录的networkeye.sqlite内。
 <pre>
-#define kSQLitePassword @"networkeye"
+# define kSQLitePassword @"networkeye"
 
-#define kSaveRequestMaxCount 300
+# define kSaveRequestMaxCount 300
 </pre>
 
 NetworkEye依赖仓库FMDB和SQLCipher。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
